### PR TITLE
feat/#23

### DIFF
--- a/src/main/java/paratrip/paratrip/board/entity/BoardEntity.java
+++ b/src/main/java/paratrip/paratrip/board/entity/BoardEntity.java
@@ -1,0 +1,39 @@
+package paratrip.paratrip.board.entity;
+
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "BOARD")
+@AllArgsConstructor
+@NoArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+@Getter
+@Builder(toBuilder = true)
+public class BoardEntity {
+	@Id
+	@Column(name = "board_seq")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long memberSeq;
+
+	@Column(name = "title", nullable = false)
+	private String title;
+
+	@Column(name = "content", nullable = false)
+	private String content;
+
+	@Column(name = "location", nullable = true)
+	private String location;
+}

--- a/src/main/java/paratrip/paratrip/board/entity/BoardImageEntity.java
+++ b/src/main/java/paratrip/paratrip/board/entity/BoardImageEntity.java
@@ -1,0 +1,41 @@
+package paratrip.paratrip.board.entity;
+
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.Fetch;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "BOARD_IMAGE")
+@AllArgsConstructor
+@NoArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+@Getter
+@Builder(toBuilder = true)
+public class BoardImageEntity {
+	@Id
+	@Column(name = "board_image_seq")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long boardImageSeq;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "board_seq")
+	private BoardEntity boardEntity;
+
+	@Column(name = "image_url")
+	private String imageURL;
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #23

## 📌 작업 내용 및 특이사항
- BoardEntity 클래스 추가
  - @Entity 및 @Table(name = "BOARD") 어노테이션을 사용하여 데이터베이스 엔티티 매핑
  - boardSeq 필드를 기본 키로 설정하고 자동 생성
  - title, content, location 필드 추가
  - Lombok 어노테이션(@AllArgsConstructor, @NoArgsConstructor, @Getter, @Builder(toBuilder = true)) 사용하여 생성자 및 게터, 빌더 메서드 자동 생성
  - @DynamicInsert 및 @DynamicUpdate 어노테이션을 사용하여 변경된 필드만 업데이트

- BoardImageEntity 클래스 추가
  - @Entity 및 @Table(name = "BOARD_IMAGE") 어노테이션을 사용하여 데이터베이스 엔티티 매핑
  - boardImageSeq 필드를 기본 키로 설정하고 자동 생성
  - BoardEntity와 다대일 관계 설정 (Lazy Fetch 타입)
  - Lombok 어노테이션(@AllArgsConstructor, @NoArgsConstructor, @Getter, @Builder(toBuilder = true)) 사용하여 생성자 및 게터, 빌더 메서드 자동 생성
  - @DynamicInsert 및 @DynamicUpdate 어노테이션을 사용하여 변경된 필드만 업데이트


## 📝 참고사항
- 

## 📚 기타
-